### PR TITLE
[HB-5717] Use a hard reference when setting InMobi listeners.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.10.5.4.1
+- Fixes an issue in which InMobi event listeners were garbage collected.
+
 ### 4.10.5.4.0
 - This version of the adapter has been certified with InMobi SDK 10.5.4.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Note the first digit of every adapter version corresponds to the major version o
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
 ### 4.10.5.4.1
-- Fixes an issue in which InMobi event listeners were garbage collected.
+- Fixed an issue where InMobi event listeners were garbage collected.
 
 ### 4.10.5.4.0
 - This version of the adapter has been certified with InMobi SDK 10.5.4.

--- a/InMobiAdapter/build.gradle.kts
+++ b/InMobiAdapter/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.10.5.4.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.10.5.4.1"
         buildConfigField("String", "CHARTBOOST_MEDIATION_INMOBI_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/InMobiAdapter/src/main/java/com/chartboost/mediation/inmobiadapter/InMobiAdapter.kt
+++ b/InMobiAdapter/src/main/java/com/chartboost/mediation/inmobiadapter/InMobiAdapter.kt
@@ -411,8 +411,7 @@ class InMobiAdapter : PartnerAdapter {
 
                     return suspendCancellableCoroutine { continuation ->
                         // Load an InMobiBanner
-                        inMobiBannerAds[request.identifier] = InMobiBanner(activity, placement)
-                        inMobiBannerAds[request.identifier]?.apply {
+                        inMobiBannerAds[request.identifier] = InMobiBanner(activity, placement).apply {
                             setEnableAutoRefresh(false)
                             setBannerSize(size.width, size.height)
                             setListener(buildBannerAdListener(
@@ -420,8 +419,9 @@ class InMobiAdapter : PartnerAdapter {
                                 partnerAdListener = partnerAdListener,
                                 continuation = continuation
                             ))
-                            load()
-                        } ?: run {
+                        }
+
+                        inMobiBannerAds[request.identifier]?.load() ?: run {
                             PartnerLogController.log(
                                 LOAD_FAILED,
                                 "inMobi banner ad is null."


### PR DESCRIPTION
## Issue:

During a session, inMobi tends to lose its callback. This generally happens during a first load attempt or when we navigate between our canary.

```
com.chartboost.heliumcanary   D  Fetching an Interstitial ad for placement id: 1638795264987 com.chartboost.heliumcanary   D  Publisher device Id is 97c2428f-419b-4680-a10b-3408d722de8f
com.chartboost.heliumcanary   D  Interstitial ad successfully fetched for placement id: 1638795264987
com.chartboost.heliumcanary   D  Successfully loaded Interstitial ad markup in the WebView for placement id: 1638795264987
com.chartboost.heliumcanary   D  Listener was garbage collected. Unable to give callback
```

> Note: I attempted a few solutions, but I keep getting the same message. Putting this as the proper a solution is discussed.
