### PR TITLE
[HB-6536] Updated adapter to use InMobi bidding API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.10.6.7.1
+- Update to utilize InMobiSDK bidding APIs.
+
 ### 4.10.6.7.0
 - This version of the adapter has been certified with InMobi SDK 10.6.7.
 

--- a/InMobiAdapter/build.gradle.kts
+++ b/InMobiAdapter/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.10.6.7.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.10.6.7.1"
         buildConfigField("String", "CHARTBOOST_MEDIATION_INMOBI_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         consumerProguardFiles("proguard-rules.pro")

--- a/InMobiAdapter/src/main/java/com/chartboost/mediation/inmobiadapter/InMobiAdapter.kt
+++ b/InMobiAdapter/src/main/java/com/chartboost/mediation/inmobiadapter/InMobiAdapter.kt
@@ -500,9 +500,10 @@ class InMobiAdapter : PartnerAdapter {
                                     continuation = continuation,
                                 ),
                             )
-                            request.adm?.toByteArray()?.let {
-                                load(it)
-                            } ?: run {
+                            val admBytes = request.adm?.toByteArray() ?: byteArrayOf()
+                            if (admBytes.isNotEmpty()) {
+                                load(admBytes)
+                            } else {
                                 load()
                             }
                         }
@@ -630,9 +631,10 @@ class InMobiAdapter : PartnerAdapter {
                             listener = partnerAdListener,
                         ),
                     ).apply {
-                        request.adm?.toByteArray()?.let {
-                            load(it)
-                        } ?: run {
+                        val admBytes = request.adm?.toByteArray() ?: byteArrayOf()
+                        if (admBytes.isNotEmpty()) {
+                            load(admBytes)
+                        } else {
                             load()
                         }
                     }

--- a/InMobiAdapter/src/main/java/com/chartboost/mediation/inmobiadapter/InMobiAdapter.kt
+++ b/InMobiAdapter/src/main/java/com/chartboost/mediation/inmobiadapter/InMobiAdapter.kt
@@ -282,8 +282,13 @@ class InMobiAdapter : PartnerAdapter {
         request: PreBidRequest,
     ): Map<String, String> {
         PartnerLogController.log(BIDDER_INFO_FETCH_STARTED)
-        PartnerLogController.log(BIDDER_INFO_FETCH_SUCCEEDED)
-        return emptyMap()
+        InMobiSdk.getToken()?.let { token ->
+            PartnerLogController.log(BIDDER_INFO_FETCH_SUCCEEDED)
+            return mapOf("token" to token)
+        } ?: run {
+            PartnerLogController.log(BIDDER_INFO_FETCH_FAILED)
+            return emptyMap()
+        }
     }
 
     /**

--- a/InMobiAdapter/src/main/java/com/chartboost/mediation/inmobiadapter/InMobiAdapter.kt
+++ b/InMobiAdapter/src/main/java/com/chartboost/mediation/inmobiadapter/InMobiAdapter.kt
@@ -500,7 +500,11 @@ class InMobiAdapter : PartnerAdapter {
                                     continuation = continuation,
                                 ),
                             )
-                            load()
+                            request.adm?.toByteArray()?.let {
+                                load(it)
+                            } ?: run {
+                                load()
+                            }
                         }
                     }
                 } ?: run {
@@ -626,7 +630,11 @@ class InMobiAdapter : PartnerAdapter {
                             listener = partnerAdListener,
                         ),
                     ).apply {
-                        load()
+                        request.adm?.toByteArray()?.let {
+                            load(it)
+                        } ?: run {
+                            load()
+                        }
                     }
             }
         } ?: run {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Chartboost Mediation InMobi adapter mediates InMobi via the Chartboost Media
 ## Integration
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-inmobi:4.10.6.7.0"
+    implementation "com.chartboost:chartboost-mediation-adapter-inmobi:4.10.6.7.1"
 ```
 
 ## Contributions


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-6536

Bid support with InMobi, SDK 10.6.7.

Their documentation:

[Bidding Integration with InMobi SDK.pdf](https://github.com/ChartBoost/chartboost-mediation-android-adapter-inmobi/files/15298686/Bidding.Integration.with.InMobi.SDK.pdf)
