### PR TITLE
4.10.6.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.10.6.7.2
+- Fix passing extras to InMobiSDK bidding APIs.
+
 ### 4.10.6.7.1
 - Update to utilize InMobiSDK bidding APIs.
 

--- a/InMobiAdapter/build.gradle.kts
+++ b/InMobiAdapter/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.10.6.7.1"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.10.6.7.2"
         buildConfigField("String", "CHARTBOOST_MEDIATION_INMOBI_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         consumerProguardFiles("proguard-rules.pro")

--- a/InMobiAdapter/src/main/java/com/chartboost/mediation/inmobiadapter/InMobiAdapter.kt
+++ b/InMobiAdapter/src/main/java/com/chartboost/mediation/inmobiadapter/InMobiAdapter.kt
@@ -1,6 +1,6 @@
 /*
  * Copyright 2023-2024 Chartboost, Inc.
- * 
+ *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file.
  */
@@ -282,7 +282,14 @@ class InMobiAdapter : PartnerAdapter {
         request: PreBidRequest,
     ): Map<String, String> {
         PartnerLogController.log(BIDDER_INFO_FETCH_STARTED)
-        InMobiSdk.getToken()?.let { token ->
+
+        val extras =
+            mapOf(
+                "tp" to "c_chartboost",
+                "tp-ver" to com.chartboost.heliumsdk.BuildConfig.CHARTBOOST_MEDIATION_VERSION,
+            )
+
+        InMobiSdk.getToken(extras = extras, keywords = null)?.let { token ->
             PartnerLogController.log(BIDDER_INFO_FETCH_SUCCEEDED)
             return mapOf("token" to token)
         } ?: run {
@@ -675,7 +682,7 @@ class InMobiAdapter : PartnerAdapter {
         private val continuationRef: WeakReference<CancellableContinuation<Result<PartnerAd>>>,
         private val request: PartnerAdLoadRequest,
         private val listener: PartnerAdListener,
-    ): InterstitialAdEventListener() {
+    ) : InterstitialAdEventListener() {
         fun resumeOnce(result: Result<PartnerAd>) {
             continuationRef.get()?.let {
                 if (it.isActive) {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Chartboost Mediation InMobi adapter mediates InMobi via the Chartboost Media
 ## Integration
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-inmobi:4.10.6.7.1"
+    implementation "com.chartboost:chartboost-mediation-adapter-inmobi:4.10.6.7.2"
 ```
 
 ## Contributions


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-7894

According to InMobi, the adapters are not setting the extras being set when requesting the token from InMobi (step 5 in the doc).  This PR addresses this issue.