### PR TITLE
Gradle 8 migration

### DIFF
--- a/InMobiAdapter/build.gradle.kts
+++ b/InMobiAdapter/build.gradle.kts
@@ -61,6 +61,7 @@ android {
 
     buildFeatures {
         viewBinding = true
+        buildConfig = true
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,8 +13,8 @@ buildscript {
 }
 
 plugins {
-    id("com.android.application") version "7.4.1" apply false
-    id("com.android.library") version "7.4.1" apply false
+    id("com.android.application") version "8.2.2" apply false
+    id("com.android.library") version "8.2.2" apply false
     id("org.jetbrains.kotlin.android") version "1.7.20" apply false
 
     kotlin("plugin.serialization") version "1.7.20"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jun 23 19:36:48 EDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Migration to Gradle 8.

Required along with https://github.com/ChartBoost/helium-android/pull/1797.