### PR TITLE
Updated CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+All official releases can be found on this repository's [releases page](https://github.com/ChartBoost/chartboost-mediation-android-adapter-inmobi/releases).
+
 ### 5.10.7.7.0
+- This version of the adapter has been certified with InMobi SDK 10.7.7.
+
+### 4.10.7.7.0
 - This version of the adapter has been certified with InMobi SDK 10.7.7.
 
 ### 5.10.7.6.0


### PR DESCRIPTION
Retroactively update the CHANGELOG to include a link to the official releases page on Github and with Mediation 4 releases (if necessary).