### PR TITLE
4.10.7.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.10.7.8.0
+- This version of the adapter has been certified with InMobi SDK 10.7.8.
+
 ### 4.10.7.7.0
 - This version of the adapter has been certified with InMobi SDK 10.7.7.
 

--- a/InMobiAdapter/build.gradle.kts
+++ b/InMobiAdapter/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         minSdk = 21
         targetSdk = 34
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.10.7.7.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.10.7.8.0"
         buildConfigField("String", "CHARTBOOST_MEDIATION_INMOBI_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         consumerProguardFiles("proguard-rules.pro")
@@ -72,7 +72,7 @@ dependencies {
     "remoteImplementation"("com.chartboost:chartboost-mediation-sdk:4.0.0")
 
     // Partner SDK
-    implementation("com.inmobi.monetization:inmobi-ads-kotlin:10.7.7")
+    implementation("com.inmobi.monetization:inmobi-ads-kotlin:10.7.8")
 
     // Partner SDK Dependencies
     implementation("androidx.appcompat:appcompat:1.5.1")

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Chartboost Mediation InMobi adapter mediates InMobi via the Chartboost Media
 ## Integration
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-inmobi:4.10.7.7.0"
+    implementation "com.chartboost:chartboost-mediation-adapter-inmobi:4.10.7.8.0"
 ```
 
 ## Contributions


### PR DESCRIPTION
This PR updates the partner version to 4.10.7.8.0 for release.

DO NOT MERGE.

This will be released once 5.10.7.8.0 has been certified (PR https://github.com/ChartBoost/chartboost-mediation-android-adapter-inmobi/pull/78).  Canary for Mediation 4 cannot build with InMobi starting in SDK version 10.7.7 due to target SDK 34 and Kotlin 1.9.0 bumps.