### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ All official releases can be found on this repository's [releases page](https://
 
 ## Mediation 4
 
+### 4.10.7.8.0
+- This version of the adapter has been certified with InMobi SDK 10.7.8.
+
 ### 4.10.7.7.0
 - This version of the adapter has been certified with InMobi SDK 10.7.7.
 


### PR DESCRIPTION
Added adapter version `4.10.7.8.0` to the CHANGELOG for PR https://github.com/ChartBoost/chartboost-mediation-android-adapter-inmobi/pull/79.